### PR TITLE
Xevra

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 *.py[cod]
 .vscode/
 *.dat
+*.swp

--- a/setup/setupdiskblackholes.py
+++ b/setup/setupdiskblackholes.py
@@ -135,5 +135,5 @@ def setup_disk_nbh(M_nsc,nbh_nstar_ratio,mbh_mstar_ratio,r_nsc_out,nsc_index_out
     # Total number of BH in disk
     Nbh_disk_total = np.rint(Nbh_disk_volume * h_disk_average)
     #print("Nbh_disk_total",Nbh_disk_total)  
-    return np.int(Nbh_disk_total)
+    return np.int64(Nbh_disk_total)
 


### PR DESCRIPTION
- Added vim swap files to gitignore
- futureproofed instance of np.int for python 3.11 in setupdiskblackholdes.py
- Attempted to patch test1_iterate.py to match behavior of test1.py (previously wasn't running at all). There may still be some dynamics missing.