### PR TITLE
Removed "DEFAULT_INI" file nonsense

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ install: clean version
 mcfacts_sim: clean
 	python3 ${MCFACTS_SIM_EXE} \
 		--n_iterations 10 \
-        --fname-ini ${FNAME_INI} \
+		--fname-ini ${FNAME_INI} \
 		--fname-log out.log \
 		--seed ${SEED}
 
@@ -64,6 +64,7 @@ vera_plots: mcfacts_sim
 
 mstar_runs:
 	python3 ${MSTAR_RUNS_EXE} \
+		--fname-ini ${FNAME_INI} \
 		--number_of_timesteps 100 \
 		--n_iterations 10 \
 		--dynamics \
@@ -71,7 +72,7 @@ mstar_runs:
 		--mstar-min 1e9 \
 		--mstar-max 1e13 \
 		--nbins 9 \
-        --scrub \
+		--scrub \
 		--fname-nal ${FNAME_GWTC2_NAL} \
 		--wkdir ${MSTAR_RUNS_WKDIR}
 	python3 ${MSTAR_PLOT_EXE} --run-directory ${MSTAR_RUNS_WKDIR}/early

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,8 @@ MSTAR_RUNS_EXE = ${HERE}/scripts/vera_mstar_bins.py
 MSTAR_PLOT_EXE = ${HERE}/src/mcfacts/outputs/plot_mcfacts_handler_quantities.py
 
 #### Setup ####
+SEED=3456789012
+FNAME_INI= ${HERE}/recipes/model_choice.ini
 MSTAR_RUNS_WKDIR = ${HERE}/runs_mstar_bins
 # NAL files might not exist unless you download them from
 # https://gitlab.com/xevra/nal-data
@@ -47,9 +49,10 @@ install: clean version
 
 mcfacts_sim: clean
 	python3 ${MCFACTS_SIM_EXE} \
-		--n_iterations 100 \
+		--n_iterations 10 \
+        --fname-ini ${FNAME_INI} \
 		--fname-log out.log \
-		--seed 3456789012
+		--seed ${SEED}
 
 plots:  mcfacts_sim
 	python3 ${POPULATION_PLOTS_EXE} 

--- a/recipes/model_choice.ini
+++ b/recipes/model_choice.ini
@@ -16,7 +16,7 @@ trap_radius = 700.
 # disk outer radius in r_g
 disk_outer_radius = 50000.
 # Maximum disk outer radius (pc) (0. turns this off)
-max_disk_radius_pc = -0.2
+max_disk_radius_pc = 0.
 # disk alpha parameter (viscosity parameter, alpha=0.01 in sirko_goodman)
 alpha = 0.01
 #

--- a/scripts/mcfacts_sim.py
+++ b/scripts/mcfacts_sim.py
@@ -107,7 +107,7 @@ def arg():
                        )
     # Mass of NSC
     parser.add_argument(
-                        "--M-nsc",
+                        "--M_nsc",
                         type=float,
                         default=3.e7,
                         help="Mass of NSC (Msun). Milky-Way NSC has 3e7 Msun. Typically 10^[6-8]"

--- a/scripts/vera_mstar_bins.py
+++ b/scripts/vera_mstar_bins.py
@@ -18,6 +18,7 @@ def arg():
     parser.add_argument("--nbins", default=9, type=int, help="Number of stellar mass bins")
     parser.add_argument("--wkdir", default='./run_many', help="top level working directory")
     parser.add_argument("--mcfacts-exe", default="./scripts/mcfacts_sim.py", help="Path to mcfacts exe")
+    parser.add_argument("--fname-ini", required=True, help="Path to mcfacts inifile")
     parser.add_argument("--vera-plots-exe", default="./scripts/vera_plots.py", help="Path to Vera plots script")
     parser.add_argument("--fname-nal", default=join(expanduser("~"), "Repos", "nal-data", "GWTC-2.nal.hdf5" ),
         help="Path to Vera's data from https://gitlab.com/xevra/nal-data")
@@ -91,8 +92,8 @@ def make_batch(opts, wkdir, mcfacts_args, mass_smbh, mass_nsc):
         pass
 
     # Make all iterations
-    cmd = "python3 %s --mass_smbh %f --M_nsc %f --work-directory %s %s"%(
-        opts.mcfacts_exe, mass_smbh, mass_nsc, wkdir, mcfacts_args)
+    cmd = "python3 %s --fname-ini %s --mass_smbh %f --M_nsc %f --work-directory %s %s"%(
+        opts.mcfacts_exe, opts.fname_ini, mass_smbh, mass_nsc, wkdir, mcfacts_args)
     print(cmd)
     if not opts.print_only:
         os.system(cmd)

--- a/src/mcfacts/outputs/mcfacts_batch_object.py
+++ b/src/mcfacts/outputs/mcfacts_batch_object.py
@@ -172,7 +172,7 @@ class McfactsBatch(object):
         # Identify output*.dat
         fname_mergers = None
         for _file in dir_files:
-            if (_file.startswith('output') and _file.endswith('.dat')):
+            if (_file.startswith('output_mergers_population') and _file.endswith('.dat')):
                 fname_mergers = abspath(join(run_directory, _file))
                 assert isfile(fname_mergers)
         # Check that we found output*.dat


### PR DESCRIPTION
Makefile:
- added SEED and FNAME_INI variables

model_choice.ini:
- disabled maximum disk radius (parsec) by default

mcfacts_sim.py
- fname-ini is now a mandatory command line argument for mcfacts_sim.py
- DEFAULT_INI is gone to remove confusion and path dependence.
- Argument parser is populated with most mcfacts ini-file arguments (excluding disk_outer_radius).