### PR TITLE
Update random number generator usage for proper reproducibility

### DIFF
--- a/src/mcfacts/mcfacts_random_state.py
+++ b/src/mcfacts/mcfacts_random_state.py
@@ -3,7 +3,7 @@ import numpy as np
 
 default_seed = 1
 # Initialize random number generator
-rng = np.random.default_rng(default_seed)
+rng = np.random.RandomState(seed=default_seed)
 
 
 def reset_random(seed):
@@ -20,5 +20,4 @@ def reset_random(seed):
     rng : numpy random number generator
         rng set with input value seed
     """
-    rng = np.random.default_rng(seed)
-    return (rng)
+    rng.seed(seed)

--- a/src/mcfacts/physics/binary/formation/add_new_binary.py
+++ b/src/mcfacts/physics/binary/formation/add_new_binary.py
@@ -61,7 +61,7 @@ def add_to_binary_obj(blackholes_binary, blackholes_pro, bh_pro_id_num_binary, i
     time_merged = np.zeros(bin_num)
     # Set up binary eccentricity around its own center of mass.
     # Draw uniform value btwn [0,1]
-    bin_ecc = rng.random(bin_num)
+    bin_ecc = rng.uniform(size=bin_num)
     gen_1 = np.zeros(bin_num)
     gen_2 = np.zeros(bin_num)
     bin_orb_ang_mom = np.zeros(bin_num)
@@ -103,7 +103,9 @@ def add_to_binary_obj(blackholes_binary, blackholes_pro, bh_pro_id_num_binary, i
         if fraction_bin_retro == 0:
             bin_orb_ang_mom[i] = 1.
         else:
-            bin_orb_ang_mom[i] = (2.0*np.around(rng.random())) - 1.0
+            # choose uniformly between [0.0,1.0), double it, subtract 1.0, and
+            #   round to nearest integer to get -1.0 or 1.0
+            bin_orb_ang_mom[i] = (2.0*np.around(rng.uniform(size=1))) - 1.0
 
     gw_strain, gw_freq = gw_strain_freq(mass_1=mass_1, mass_2=mass_2, obj_sep=bin_sep, timestep_duration_yr=-1,
                                         old_gw_freq=-1, smbh_mass=smbh_mass, agn_redshift=agn_redshift,

--- a/src/mcfacts/physics/dynamics/dynamics.py
+++ b/src/mcfacts/physics/dynamics/dynamics.py
@@ -186,7 +186,7 @@ def circular_singles_encounters_prograde(
                         prob_enc_per_timestep = prob_orbit_overlap * N_circ_orbs_per_timestep[i]
                         if prob_enc_per_timestep > 1:
                             prob_enc_per_timestep = 1
-                        random_uniform_number = rng.random()
+                        random_uniform_number = rng.uniform(size=1)
                         #print(f"++++++++++circular_singles_encounters_prograde {random_uniform_number}")
                         if random_uniform_number < prob_enc_per_timestep:
                             indx_array = circ_prograde_population_indices[0]
@@ -413,7 +413,7 @@ def circular_binaries_encounters_ecc_prograde(
 
                         if prob_enc_per_timestep > 1:
                             prob_enc_per_timestep = 1
-                        random_uniform_number = rng.random()
+                        random_uniform_number = rng.uniform(size=1)
                         #print(f"++++++++++circular_binaries_encounters_ecc_prograde {random_uniform_number}")
 
                         if random_uniform_number < prob_enc_per_timestep:
@@ -698,7 +698,7 @@ def circular_binaries_encounters_circ_prograde(
                         v_crit_kms = np.sqrt(scipy.constants.G*disk_bins_bhbh[2,i]*disk_bins_bhbh[3,i]*temp_bin_mass*solar_mass/(circ_prograde_population_masses[j]*bin_masses[i]*bin_separations[i]*rg_in_meters))/1.e3 
                         if prob_enc_per_timestep > 1:
                             prob_enc_per_timestep = 1
-                        random_uniform_number = rng.random()
+                        random_uniform_number = rng.uniform(size=1)
                         #print(f"++++++++++circular_binaries_encounters_circ_prograde {random_uniform_number}")
                         if random_uniform_number < prob_enc_per_timestep:
                             #Perturb *this* ith binary depending on how hard it already is.
@@ -883,7 +883,7 @@ def bin_spheroid_encounter(
         excluded_angles = (time_passed/crit_time)*180
         if R<10^3r_g
             #Draw random integer in range [excluded_angles,360-(excluded_angles)]
-            i3 = rng.integers(excluded_angles,360-(excluded_angles))....(8)
+            i3 = rng.randint(excluded_angles, 360-(excluded_angles))....(8)
     
     Calculate velocity of encounter compared to a_bin. 
     Ignore what happens to m3, since it's a random draw from the NSC and we are not tracking individual NSC components.
@@ -996,20 +996,20 @@ def bin_spheroid_encounter(
             raise RuntimeError("Unrecognized bin_com")
 
         # Based on est encounter rate, calculate if binary actually has a spheroid encounter
-        random_uniform_number = rng.random()
+        random_uniform_number = rng.uniform(size=1)
         #print(f"++++++++++bin_spheroid_rand1 {random_uniform_number}")
 
         if random_uniform_number < enc_rate:
             # Have already generated spheroid interaction, so a_3 is not far off a_bbh (unless super high ecc). 
             # Assume a_3 is similar to a_bbh (within a factor of O(3), so allowing for modest relative eccentricity)    
             # i.e. a_3=[10^-0.5,10^0.5]*a_bbh.
-            random_uniform_number2 = -0.5 + rng.random()
+            random_uniform_number2 = -0.5 + rng.uniform(size=1)
             #print(f"++++++++++bin_spheroid_rand2 {random_uniform_number2}")
             radius_3 = bin_coms[i]*(10**(random_uniform_number2))
             # Generate random interloper mass from IMF
             # NOTE: Stars should be most common sph component. Switch to BH after some long time.
             mode_star = 2.0
-            mass_3 = (rng.pareto(nsc_bh_imf_powerlaw_index,1)+1)*mode_star
+            mass_3 = (rng.pareto(nsc_bh_imf_powerlaw_index, size=1) + 1) * mode_star
             #print(f"++++++++++bin_spheroid_mass3 {mass_3}")
             # K.E_3 in Joules
             # Keplerian velocity of ecc prograde orbiter around SMBH (=c/sqrt(a/r_g))
@@ -1029,11 +1029,11 @@ def bin_spheroid_encounter(
                     # i3 in units of degrees
                     # where 0 deg = disk mid-plane prograde, 180 deg= disk mid-plane retrograde,
                     # 90deg = aligned with L_disk, 270 deg = anti-aligned with disk)
-                    i3 = rng.integers(excluded_angles,360-(excluded_angles))
+                    i3 = rng.randint(low=excluded_angles, high=360-(excluded_angles))
                 #Make grind down much slower at >1000r_g (say all captured in 20Myrs for <5.e4r_g)
                 if radius_3 > crit_radius:
                     excluded_angles = 0.05*(time_passed/crit_time)*180
-                    i3 = rng.integers(excluded_angles,360-(excluded_angles))
+                    i3 = rng.randint(low=excluded_angles, high=360-(excluded_angles))
             
             if time_passed > crit_time:
                 # No encounters inside R<10^3r_g
@@ -1043,7 +1043,7 @@ def bin_spheroid_encounter(
                 if radius_3 > crit_radius:
                     # All stars captured out to 1.e4r_g after 100Myrs
                     excluded_angles = 0.01*(time_passed/crit_time)*180
-                    i3 = rng.integers(excluded_angles,360-(excluded_angles))
+                    i3 = rng.randint(low=excluded_angles, high=360-(excluded_angles))
                 #print(f"++++++++++bin_spheroid_i3xxx {i3}")
 
             #Convert i3 to radians

--- a/src/mcfacts/setup/initializediskstars.py
+++ b/src/mcfacts/setup/initializediskstars.py
@@ -31,7 +31,7 @@ def init_single_stars(opts, id_start_val=None):
                                                             nsc_imf_star_powerlaw_index=opts.nsc_imf_star_powerlaw_index)
 
     # Generating star locations in an x^2 distribution
-    x_vals = rng.uniform(0.002, 1, star_num_initial)
+    x_vals = rng.uniform(low=0.002, high=1, size=star_num_initial)
     r_locations_initial = np.sqrt(x_vals)
     r_locations_initial_scaled = r_locations_initial*opts.disk_radius_trap
 

--- a/src/mcfacts/setup/setupdiskblackholes.py
+++ b/src/mcfacts/setup/setupdiskblackholes.py
@@ -21,8 +21,7 @@ def setup_disk_blackholes_location(disk_bh_num, disk_outer_radius,disk_inner_sta
     """
     # ISCO defined here. Need to put this in the .ini file.
     #disk_inner_stable_circ_orbit = 6.0
-    integer_nbh = int(disk_bh_num)
-    bh_initial_locations = disk_outer_radius*rng.random(integer_nbh)
+    bh_initial_locations = disk_outer_radius * rng.uniform(size=disk_bh_num)
     sma_too_small = np.where(bh_initial_locations < disk_inner_stable_circ_orb)
     bh_initial_locations[sma_too_small] = disk_inner_stable_circ_orb
     return bh_initial_locations
@@ -31,7 +30,7 @@ def setup_prior_blackholes_indices(prograde_n_bh, prior_bh_locations):
     #Return an array of indices which allow us to read prior BH properties & replace prograde BH with these.
     integer_nbh = int(prograde_n_bh)
     len_prior_locations = (prior_bh_locations.size)-1
-    bh_indices = np.rint(len_prior_locations*rng.random(integer_nbh))
+    bh_indices = np.rint(len_prior_locations * rng.uniform(size=integer_nbh))
     return bh_indices
 
 def setup_disk_blackholes_masses(disk_bh_num,nsc_bh_imf_mode,nsc_bh_imf_max_mass,nsc_bh_imf_powerlaw_index,mass_pile_up):
@@ -56,13 +55,12 @@ def setup_disk_blackholes_masses(disk_bh_num,nsc_bh_imf_mode,nsc_bh_imf_max_mass
         disk_bh_initial_masses: float array
             Array of disk BH initial masses
     """
-    
-    integer_nbh = int(disk_bh_num)
-    disk_bh_initial_masses = (rng.pareto(nsc_bh_imf_powerlaw_index,integer_nbh)+1)*nsc_bh_imf_mode
+
+    disk_bh_initial_masses = (rng.pareto(nsc_bh_imf_powerlaw_index, size=disk_bh_num) + 1) * nsc_bh_imf_mode
     #impose mass pile up condition (should be set in .ini). Default is 35Msun (for max of 40Msun).
     #critical_bh_mass = 35.0
     mass_diff = nsc_bh_imf_max_mass - mass_pile_up
-    disk_bh_initial_masses[disk_bh_initial_masses > nsc_bh_imf_max_mass] = mass_pile_up + np.rint(mass_diff*rng.random())
+    disk_bh_initial_masses[disk_bh_initial_masses > nsc_bh_imf_max_mass] = mass_pile_up + np.rint(mass_diff*rng.uniform())
     return disk_bh_initial_masses
 
 
@@ -84,9 +82,8 @@ def setup_disk_blackholes_spins(disk_bh_num, nsc_bh_spin_dist_mu, nsc_bh_spin_di
         disk_bh_initial_spins : float array
             Array of initial BH spins of size disk_bh_num
     """
-    
-    integer_nbh = int(disk_bh_num)
-    disk_bh_initial_spins = rng.normal(nsc_bh_spin_dist_mu, nsc_bh_spin_dist_sigma, integer_nbh)
+
+    disk_bh_initial_spins = rng.normal(loc=nsc_bh_spin_dist_mu, scale=nsc_bh_spin_dist_sigma, size=disk_bh_num)
     return disk_bh_initial_spins
 
 
@@ -107,11 +104,10 @@ def setup_disk_blackholes_spin_angles(disk_bh_num, disk_bh_initial_spins):
         disk_bh_initial_spins : float array
             Array of initial BH spins of size disk_bh_num
     """
-    
-    integer_nbh = int(disk_bh_num)
+
     bh_initial_spin_indices = np.array(disk_bh_initial_spins)
     negative_spin_indices = np.where(bh_initial_spin_indices < 0.)
-    disk_bh_initial_spin_angles = rng.uniform(0.,1.57,integer_nbh)
+    disk_bh_initial_spin_angles = rng.uniform(low=0., high=1.57, size=disk_bh_num)
     disk_bh_initial_spin_angles[negative_spin_indices] = disk_bh_initial_spin_angles[negative_spin_indices] + 1.57
     return disk_bh_initial_spin_angles
 
@@ -130,9 +126,8 @@ def setup_disk_blackholes_orb_ang_mom(disk_bh_num):
         disk_bh_initial_orb_ang_mom : float array
             Array of initial BH orb ang mom of size disk_bh_num
     """
-    
-    integer_nbh = int(disk_bh_num)
-    random_uniform_number = rng.random((integer_nbh,))
+
+    random_uniform_number = rng.uniform(size=disk_bh_num)
     disk_bh_initial_orb_ang_mom = (2.0*np.around(random_uniform_number)) - 1.0
     return disk_bh_initial_orb_ang_mom
 
@@ -152,9 +147,8 @@ def setup_disk_blackholes_eccentricity_thermal(disk_bh_num):
         disk_bh_initial_orb_ecc : float array
             Array of initial BH orb eccentricity of size disk_bh_num
     """
-    
-    integer_nbh = int(disk_bh_num)
-    random_uniform_number = rng.random((integer_nbh,))
+
+    random_uniform_number = rng.uniform(size=disk_bh_num)
     disk_bh_initial_orb_ecc = np.sqrt(random_uniform_number)
     return disk_bh_initial_orb_ecc
 
@@ -179,34 +173,10 @@ def setup_disk_blackholes_eccentricity_uniform(disk_bh_num, disk_bh_orb_ecc_max_
         disk_bh_initial_orb_ecc : float array
             Array of initial BH orb eccentricity of size disk_bh_num
     """
-    
-    integer_nbh = int(disk_bh_num)
-    random_uniform_number = rng.random((integer_nbh,))
-    bh_initial_orb_ecc = random_uniform_number*disk_bh_orb_ecc_max_init
-    return bh_initial_orb_ecc
 
-def setup_disk_blackholes_inclination(disk_bh_num):
-    """Return an array of disk BH initial orbital inclinations of size disk_bh_num. 
-    Right now returns an initial distribution of inclination angles that are 0.0
-    To do: initialize inclinations so random draw with i <h (so will need to input bh_locations and disk_aspect_ratio)
-    and then damp inclination.
-    To do: calculate v_kick for each merger and then the (i,e) orbital elements for the newly merged BH. 
-    Then damp (i,e) as appropriate. Return an initial distribution of inclination angles that are 0 deg.
-    
-    Parameters
-    ----------
-        disk_bh_num : int
-            Integer number of BH initially embedded in disk
-    Returns
-    -------
-        disk_bh_initial_orb_inc : float array
-            Array of initial BH orb eccentricity of size disk_bh_num
-    """
-    
-    integer_nbh = int(disk_bh_num)
-    # For now, inclinations are zeros
-    disk_bh_orb_inc_init = np.zeros((integer_nbh,),dtype = float)
-    return disk_bh_orb_inc
+    random_uniform_number = rng.uniform(size=disk_bh_num)
+    bh_initial_orb_ecc = random_uniform_number * disk_bh_orb_ecc_max_init
+    return bh_initial_orb_ecc
 
 def setup_disk_blackholes_incl(disk_bh_num, disk_bh_locations, disk_bh_orb_ang_mom, disk_aspect_ratio):
     """Return an array of disk BH initial orbital inclinations of size disk_bh_num. 
@@ -233,12 +203,11 @@ def setup_disk_blackholes_incl(disk_bh_num, disk_bh_locations, disk_bh_orb_ang_m
     """
     # Return an array of BH orbital inclinations
     # initial distribution is not 0.0
-    integer_nbh = int(disk_bh_num)
     # what is the max height at the orbiter location that keeps it in the disk?
     max_height = disk_bh_locations * disk_aspect_ratio(disk_bh_locations)
     # reflect that height to get the min
     min_height = -max_height
-    random_uniform_number = rng.random((integer_nbh,))
+    random_uniform_number = rng.uniform(size=disk_bh_num)
     # pick the actual height between the min and max, then reset zero point
     height_range = max_height - min_height
     actual_height_range = height_range * random_uniform_number
@@ -265,10 +234,8 @@ def setup_disk_blackholes_circularized(disk_bh_num,disk_bh_pro_orb_ecc_crit):
         disk_bh_orb_ecc_init : float array
             Array of initial BH orb eccentricity of size disk_bh_num. Assumed circularized.
     """
-    
-    integer_nbh = int(disk_bh_num)
-    
-    disk_bh_orb_ecc_init = disk_bh_pro_orb_ecc_crit*np.zeros((integer_nbh,),dtype = float)
+
+    disk_bh_orb_ecc_init = disk_bh_pro_orb_ecc_crit*np.zeros((disk_bh_num,),dtype = float)
     return disk_bh_orb_ecc_init
 
 def setup_disk_blackholes_arg_periapse(disk_bh_num):
@@ -287,10 +254,9 @@ def setup_disk_blackholes_arg_periapse(disk_bh_num):
         disk_bh_orb_ecc_init : float array
             Array of initial BH orb eccentricity of size disk_bh_num. Assumed circularized.
     """
-    
-    integer_nbh = int(disk_bh_num)
-    random_uniform_number = rng.random((integer_nbh,))
-    
+
+    random_uniform_number = rng.uniform(size=disk_bh_num)
+
     bh_initial_orb_arg_periapse = 0.5 * np.pi * np.around(random_uniform_number)
 
     return bh_initial_orb_arg_periapse

--- a/src/mcfacts/setup/setupdiskstars.py
+++ b/src/mcfacts/setup/setupdiskstars.py
@@ -20,7 +20,7 @@ def setup_disk_stars_orb_a(star_num, disk_radius_outer):
     star_orb_a_initial : numpy array
         semi-major axes for stars
     """
-    star_orb_a_initial = disk_radius_outer*rng.random(size=star_num)
+    star_orb_a_initial = disk_radius_outer*rng.uniform(size=star_num)
     return (star_orb_a_initial)
 
 
@@ -167,7 +167,7 @@ def setup_disk_stars_spin_angles(star_num, star_spins_initial):
 
     star_initial_spin_indices = np.array(star_spins_initial)
     negative_spin_indices = np.where(star_initial_spin_indices < 0.)
-    star_spin_angles_initial = rng.uniform(0., 1.57, star_num)
+    star_spin_angles_initial = rng.uniform(low=0., high=1.57, size=star_num)
     star_spin_angles_initial[negative_spin_indices] = star_spin_angles_initial[negative_spin_indices] + 1.57
     return (star_spin_angles_initial)
 
@@ -198,7 +198,7 @@ def setup_disk_stars_orb_ang_mom(star_num,
     star_orb_ang_mom_initial : numpy array
         orbital angular momentum
     """
-    random_uniform_number = rng.random(size=star_num)
+    random_uniform_number = rng.uniform(size=star_num)
     star_orb_ang_mom_initial_sign = (2.0*np.around(random_uniform_number)) - 1.0
     star_orb_ang_mom_initial_value = mass_reduced*np.sqrt(G.to('m^3/(M_sun s^2)').value*mass_total*orb_a*(1-orb_inc**2))
     star_orb_ang_mom_initial = star_orb_ang_mom_initial_sign*star_orb_ang_mom_initial_value
@@ -230,7 +230,7 @@ def setup_disk_stars_arg_periapse(star_num):
         arguments for orbital periapse
     """
 
-    random_uniform_number = rng.random(star_num)
+    random_uniform_number = rng.uniform(size=star_num)
     star_orb_arg_periapse_initial = 0.5 * np.pi * np.around(random_uniform_number)
 
     return (star_orb_arg_periapse_initial)
@@ -259,7 +259,7 @@ def setup_disk_stars_eccentricity_thermal(star_num):
     star_initial_orb_ecc : float array
         orbital eccentricities
     """
-    random_uniform_number = rng.random(size=star_num)
+    random_uniform_number = rng.uniform(size=star_num)
     star_orb_ecc_initial = np.sqrt(random_uniform_number)
     return (star_orb_ecc_initial)
 
@@ -287,7 +287,7 @@ def setup_disk_stars_eccentricity_uniform(star_num):
     star_initial_orb_ecc : float array
         orbital eccentricities
     """
-    random_uniform_number = rng.random(size=star_num)
+    random_uniform_number = rng.uniform(size=star_num)
     star_orb_ecc_initial = random_uniform_number
     return (star_orb_ecc_initial)
 
@@ -331,7 +331,7 @@ def setup_disk_stars_inclination_toinclude(star_num,
     max_height = star_orb_a * disk_aspect_ratio(star_orb_a)
     # reflect that height to get the min
     min_height = -max_height
-    random_uniform_number = rng.random(size=star_num)
+    random_uniform_number = rng.uniform(size=star_num)
     # pick the actual height between the min and max, then reset zero point
     height_range = max_height - min_height
     actual_height_range = height_range * random_uniform_number


### PR DESCRIPTION
The McFACTS random number generator now uses the `np.random.RandomState()` object class.
Documentation Link: [RandomState v.1.26](https://numpy.org/doc/1.26/reference/random/legacy.html)

1. change calls from `rng.random()` to `rng.uniform()` since the former is not a method in the documentation despite functioning if used.
2. remove superfluous type checking `int(int)` 
3. remove deprecated and unused function `setup_disk_blackholes_inclination()` since it has been superseded by `setup_disk_blackholes_incl()`
4. change calls from `rng.integers()` to `rng.randint()`
