### PR TITLE
update default behavior to use pAGN disk models

### DIFF
--- a/recipes/model_choice_old.ini
+++ b/recipes/model_choice_old.ini
@@ -12,7 +12,7 @@ smbh_mass = 1.e8
 # Specify prefix to filenames for input disk model
 disk_model_name = 'sirko_goodman'
 # pAGN flag (0/1) boolean
-flag_use_pagn = 0
+flag_use_pagn = 1
 
 # trap radius in r_g
 disk_radius_trap = 700.

--- a/src/mcfacts/external/DiskModelsPAGN.py
+++ b/src/mcfacts/external/DiskModelsPAGN.py
@@ -42,7 +42,7 @@ class AGNGasDiskModel(object):
         else:
             np.savetxt(filename, np.vstack((R/ct.pc, Omega, T, rho, h, cs, tauV, Q)).T)
 
-    def return_disk_surf_model(self, flag_truncate_disk=True):
+    def return_disk_surf_model(self, flag_truncate_disk=False):
         """Generate disk surface model functions
 
         Interpolate and return disk surface model functions as a function of the disk radius.
@@ -56,7 +56,7 @@ class AGNGasDiskModel(object):
         ----------
         flag_truncate_disk : bool, optional
             If `True`, truncate these functions at the radius where star formation starts
-            in the gas disk. If `False`, do not truncate, by default `True`.
+            in the gas disk. If `False`, do not truncate. By default `False`.
 
         Returns
         -------
@@ -73,12 +73,12 @@ class AGNGasDiskModel(object):
         """
 
         # convert to R_g (=R/( M G/c^2) explicitly, using internal structures
-        R = self.disk_model.R / (self.disk_model.Rs/2)
+        R = self.disk_model.R / (self.disk_model.Rs / 2)
         R_agn = self.disk_model.R_AGN / (self.disk_model.Rs / 2)
         Sigma = 2 * self.disk_model.h * self.disk_model.rho  # SI density
         kappa = 2 * self.disk_model.tauV / Sigma # Opacity = 2*tau/Sigma
         if flag_truncate_disk: # truncate to gas part of disk (no SFR)
-            R=R[:self.disk_model.isf]
+            R = R[:self.disk_model.isf]
             Sigma = Sigma[:self.disk_model.isf]
             kappa = kappa[:self.disk_model.isf]
 

--- a/src/mcfacts/inputs/data/model_choice.ini
+++ b/src/mcfacts/inputs/data/model_choice.ini
@@ -12,7 +12,7 @@ smbh_mass = 1.e8
 # Specify prefix to filenames for input disk model
 disk_model_name = 'sirko_goodman'
 # pAGN flag (0/1) boolean
-flag_use_pagn = 0
+flag_use_pagn = 1
 
 # trap radius in r_g
 disk_radius_trap = 700.


### PR DESCRIPTION
pAGN is now invoked by default to construct the disk model

1. includes a radial dependent opacity (important for migration)
2. truncation of the disk handled by `disk_radius_outer`

Produces these models.
![disk_model](https://github.com/user-attachments/assets/b89a80ff-d68c-41fb-8904-41e706ce06a8)
